### PR TITLE
fix: add contents write permission for README badge updates

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -7,8 +7,11 @@ on:
     branches: [main]
 
 permissions:
-  contents: read
+  contents: write
   actions: read
+  pull-requests: write
+  pages: write
+  id-token: write
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Summary

Fixes GitHub Actions permission issue preventing README coverage badge updates on main branch.

## Problem

Main branch CI is failing with 403 Forbidden error when trying to push README badge updates:
```
remote: Write access to repository not granted.
fatal: unable to access 'https://github.com/sog4be/sakurs/': The requested URL returned error: 403
```

## Root Cause

The coverage workflow has `contents: read` permission but needs `contents: write` to push commits back to the main branch for README badge updates.

## Solution

Update GitHub Actions permissions to include:
- `contents: write` - Required for git push operations
- `pull-requests: write` - For PR comments  
- `pages: write` - For GitHub Pages deployment
- `id-token: write` - For Pages authentication

## Verification

This change will allow the README badge update step to successfully commit and push changes to main branch without permission errors.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🔧 Build/CI configuration change

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>