### PR TITLE
fix: handle year abbreviation apostrophes in enclosure suppression

### DIFF
--- a/sakurs-core/tests/apostrophe_handling_tests.rs
+++ b/sakurs-core/tests/apostrophe_handling_tests.rs
@@ -45,7 +45,7 @@ fn test_possessive_forms() {
             vec![32, 46],
         ),
         ("James' car is fast. Mary's is faster.", vec![19, 37]),
-        ("The '90s were great. The 2000s too.", vec![]), // TODO: Fix apostrophe Δ suppression regression - should detect [20, 35]
+        ("The '90s were great. The 2000s too.", vec![20, 35]), // Fixed: apostrophe Δ suppression now works correctly
     ];
 
     for (text, expected_offsets) in test_cases {
@@ -168,7 +168,7 @@ fn test_edge_cases() {
         // Year abbreviation
         (
             "The '60s and '70s were different. Times changed.",
-            vec![], // TODO: Fix apostrophe Δ suppression regression - should detect [33, 48]
+            vec![33, 48], // Fixed: apostrophe Δ suppression now works correctly
         ),
     ];
 


### PR DESCRIPTION
## Summary

This PR fixes a regression where year abbreviations like '90s and '60s were incorrectly treated as opening quotes, causing all subsequent sentence boundaries to be suppressed. The fix adds proper detection and suppression of apostrophes in year abbreviation patterns.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting (no functional changes)
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [x] 🧪 Test addition or update
- [ ] 🔧 Build/CI configuration change

## Related Issues

Partially addresses Issue #99 - Apostrophe handling regression

## Changes Made

### Core Changes
- Added `is_year_abbreviation()` method to `EnglishEnclosureSuppressor` to detect patterns like '90s, '60s
- Updated `should_suppress_enclosure()` to include year abbreviation check for apostrophes
- The method checks for apostrophes preceded by whitespace and followed by exactly 2 digits + 's'

### Testing Changes
- Added comprehensive unit tests for year abbreviation patterns in `test_year_abbreviations()`
- Updated test expectations in `apostrophe_handling_tests.rs` to reflect correct boundary detection
- Tests now verify both ASCII and Unicode apostrophes are handled correctly

### Documentation Changes
- Added inline documentation for the new `is_year_abbreviation()` method
- Updated test comments to indicate the regression has been fixed

## How Has This Been Tested?

### Test Environment
- Rust version: 1.81+
- Operating System: macOS Darwin 24.5.0
- Architecture: darwin

### Test Cases
- [x] Unit tests pass (`cargo test`)
- [x] Integration tests pass
- [x] Benchmarks run successfully (if applicable)
- [x] Manual testing performed

### Performance Impact
No performance impact - the change adds a simple pattern check during enclosure suppression.

## Algorithm/Architecture Impact

- [ ] This change affects the core algorithm
- [ ] This change affects the hexagonal architecture layers
- [x] This change maintains monoid properties
- [x] This change preserves parallel processing capabilities

## Checklist

### Code Quality
- [x] I have performed a self-review of my code
- [x] My code follows the project's style guidelines (`cargo fmt`)
- [x] I have resolved all `cargo clippy` warnings
- [x] I have added rustdoc comments for public APIs
- [x] My code is properly documented with clear variable names and comments for complex logic

### Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added property tests for core algorithm changes (if applicable)
- [ ] I have included benchmarks for performance-critical changes (if applicable)

### Documentation
- [x] I have updated relevant documentation
- [ ] I have updated the CHANGELOG.md (if applicable)
- [x] I have read and understood the [Architecture Documentation](docs/ARCHITECTURE.md)
- [x] I have considered the impact on the [Delta-Stack Algorithm](docs/DELTA_STACK_ALGORITHM.md)

### Dependencies
- [x] I have not introduced unnecessary dependencies
- [x] New dependencies are properly justified in the commit message
- [x] Dependencies are added to the appropriate workspace configuration

## Screenshots/GIFs

N/A

## Additional Context

This is a targeted fix for the year abbreviation aspect of Issue #99. The issue also mentions other problems (quote suppression and list items) which will need separate fixes.

The fix is minimal and focused - it adds a specific pattern check without changing the overall architecture or affecting other functionality.

## Reviewer Notes

Please pay attention to:
1. The pattern matching logic in `is_year_abbreviation()` - it should only match apostrophes followed by exactly 2 digits and 's'
2. The test coverage for edge cases (e.g., '9s, '900s should NOT be suppressed)
3. The fix maintains the existing behavior for all other apostrophe patterns

---

**Note for Reviewers**: Please ensure changes maintain the mathematical properties of the Delta-Stack Monoid algorithm and don't break parallel processing guarantees.