### PR TITLE
test(python): add Japanese tests, fix boundary extraction, and improve dev workflow

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -124,9 +124,22 @@ jobs:
           uv sync --dev
           # Build wheel instead of editable install for consistent behavior
           uv run maturin build --release --features extension-module -o dist
+          
+      - name: Install built wheel (Unix)
+        if: runner.os != 'Windows'
+        run: |
+          cd sakurs-py
           # Find and install the built wheel
           WHEEL_FILE=$(ls dist/*.whl | head -1)
           uv pip install --force-reinstall "$WHEEL_FILE"
+          
+      - name: Install built wheel (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          cd sakurs-py
+          # Find and install the built wheel
+          $wheel = Get-ChildItem -Path dist -Filter *.whl | Select-Object -First 1
+          uv pip install --force-reinstall $wheel.FullName
       
       - name: Run Python tests
         run: |

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -122,7 +122,9 @@ jobs:
         run: |
           cd sakurs-py
           uv sync --dev
-          uv run maturin develop --features extension-module
+          # Build wheel instead of editable install for consistent behavior
+          uv run maturin build --release --features extension-module
+          uv pip install --force-reinstall target/wheels/*.whl
       
       - name: Run Python tests
         run: |

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -123,8 +123,10 @@ jobs:
           cd sakurs-py
           uv sync --dev
           # Build wheel instead of editable install for consistent behavior
-          uv run maturin build --release --features extension-module
-          uv pip install --force-reinstall target/wheels/*.whl
+          uv run maturin build --release --features extension-module -o dist
+          # Find and install the built wheel
+          WHEEL_FILE=$(ls dist/*.whl | head -1)
+          uv pip install --force-reinstall "$WHEEL_FILE"
       
       - name: Run Python tests
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -275,3 +275,37 @@ EOF
 - Debug session logs and findings
 - Temporary research and analysis documents
 - Progress tracking and status reports
+
+## Python Bindings Development
+
+### Development Build Process
+**IMPORTANT**: Avoid using `maturin develop` for Python bindings development as it creates editable installs that don't update properly when Rust code changes.
+
+Instead, use:
+```bash
+# Build and install wheel (recommended)
+cd sakurs-py
+maturin build --release --features extension-module
+uv pip install --force-reinstall target/wheels/*.whl
+
+# Or use the Makefile
+make py-dev
+
+# After installation, use .venv/bin/python directly
+.venv/bin/python -m pytest tests/
+```
+
+### Common Issues
+- **Stale binaries**: If Python tests pass but don't reflect recent Rust changes, you may have a stale `.so` file from an editable install
+- **uv run reverts**: The `uv run` command may automatically revert to editable installs. Use `.venv/bin/python` directly after installing the wheel
+- **Development workflow**: Always rebuild and reinstall the wheel when making Rust code changes
+
+### Testing Python Bindings
+```bash
+# Run tests after building
+cd sakurs-py
+.venv/bin/python -m pytest tests/ -v
+
+# Or use make command
+make py-test
+```

--- a/Makefile
+++ b/Makefile
@@ -193,8 +193,10 @@ py-dev:
 	@echo "🐍 Building Python bindings for development..."
 	@if [ -d sakurs-py ]; then \
 		cd sakurs-py && \
-		uv run maturin develop --features extension-module && \
-		echo "✅ Python bindings built for development!"; \
+		uv run maturin build --release --features extension-module && \
+		uv pip install --force-reinstall target/wheels/*.whl && \
+		echo "✅ Python bindings built and installed from wheel!"; \
+		echo "💡 Note: Use .venv/bin/python directly instead of 'uv run' to avoid editable install issues"; \
 	else \
 		echo "❌ sakurs-py directory not found"; \
 		exit 1; \

--- a/Makefile
+++ b/Makefile
@@ -193,8 +193,9 @@ py-dev:
 	@echo "🐍 Building Python bindings for development..."
 	@if [ -d sakurs-py ]; then \
 		cd sakurs-py && \
-		uv run maturin build --release --features extension-module && \
-		uv pip install --force-reinstall target/wheels/*.whl && \
+		uv run maturin build --release --features extension-module -o dist && \
+		WHEEL_FILE=$$(ls dist/*.whl | head -1) && \
+		uv pip install --force-reinstall "$$WHEEL_FILE" && \
 		echo "✅ Python bindings built and installed from wheel!"; \
 		echo "💡 Note: Use .venv/bin/python directly instead of 'uv run' to avoid editable install issues"; \
 	else \

--- a/sakurs-py/README.md
+++ b/sakurs-py/README.md
@@ -135,7 +135,42 @@ sentences = sakurs.split("No punctuation")  # Returns ["No punctuation"]
 
 ## Development
 
-This package is built with PyO3 and maturin. See the main repository for development setup.
+This package is built with PyO3 and maturin.
+
+### Building from Source
+
+For development, we recommend building and installing wheels rather than using editable installs:
+
+```bash
+# Build the wheel
+maturin build --release --features extension-module
+
+# Install the wheel (force reinstall to ensure updates)
+pip install --force-reinstall target/wheels/*.whl
+```
+
+**Important Note**: Avoid using `pip install -e .` or `maturin develop` as they can lead to stale binaries that don't reflect Rust code changes. The editable install mechanism doesn't properly track changes in the compiled Rust extension module.
+
+### Development Workflow
+
+1. Make changes to the Rust code
+2. Build the wheel: `maturin build --release --features extension-module`
+3. Install the wheel: `pip install --force-reinstall target/wheels/*.whl`
+4. Run tests: `python -m pytest tests/`
+
+For convenience, you can use the Makefile from the project root:
+```bash
+make py-dev  # Builds and installs the wheel
+make py-test # Builds, installs, and runs tests
+```
+
+### Troubleshooting
+
+If your changes aren't reflected after rebuilding:
+- Check if you have an editable install: `pip show sakurs` (look for "Editable project location")
+- Uninstall completely: `pip uninstall sakurs -y`
+- Reinstall from wheel as shown above
+- Use `.venv/bin/python` directly instead of `uv run` to avoid automatic editable install restoration
 
 ## License
 

--- a/sakurs-py/pyproject.toml
+++ b/sakurs-py/pyproject.toml
@@ -81,6 +81,8 @@ extend-select = [
 # PyO3 specific ignores
 "src/lib.rs" = ["D"]  # Don't check Rust files
 "*.pyi" = ["D"]       # Type stubs don't need docstrings
+# Japanese language tests contain fullwidth punctuation which is intentional
+"tests/test_*.py" = ["RUF001", "PLR2004"]  # Allow fullwidth chars and magic numbers in tests
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/sakurs-py/src/lib.rs
+++ b/sakurs-py/src/lib.rs
@@ -110,6 +110,46 @@ mod tests {
     }
 
     #[test]
+    fn test_japanese_sentence_splitting() {
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|py| {
+            // Create Japanese processor
+            let processor =
+                PyProcessor::new("ja", None).expect("Failed to create Japanese processor");
+
+            // Test basic Japanese text
+            let text = "こんにちは。元気ですか？はい、元気です！";
+            let result = processor.split(text, None, py);
+
+            assert!(result.is_ok());
+            let sentences = result.unwrap();
+
+            // Should split into 3 sentences
+            assert_eq!(
+                sentences.len(),
+                3,
+                "Expected 3 sentences but got {}",
+                sentences.len()
+            );
+            assert_eq!(sentences[0], "こんにちは。");
+            assert_eq!(sentences[1], "元気ですか？");
+            assert_eq!(sentences[2], "はい、元気です！");
+        });
+    }
+
+    #[test]
+    fn test_direct_core_japanese() {
+        // Test core directly without Python bindings
+        use sakurs_core::{Input, SentenceProcessor};
+
+        let processor = SentenceProcessor::with_language("ja").unwrap();
+        let text = "こんにちは。元気ですか？はい、元気です！";
+        let result = processor.process(Input::from_text(text)).unwrap();
+
+        assert_eq!(result.boundaries.len(), 3, "Expected 3 boundaries");
+    }
+
+    #[test]
     fn test_config_creation() {
         let config = PyProcessorConfig::new(4096, 128, Some(2), 1048576);
         assert_eq!(config.chunk_size, 4096);

--- a/sakurs-py/src/processor.rs
+++ b/sakurs-py/src/processor.rs
@@ -71,6 +71,7 @@ impl PyProcessor {
 
         // Convert boundaries to sentence list
         let boundaries: Vec<usize> = output.boundaries.iter().map(|b| b.offset).collect();
+
         let result = PyProcessingResult::new(boundaries, output.metadata.stats, text.to_string());
 
         Ok(result.sentences())

--- a/sakurs-py/src/types.rs
+++ b/sakurs-py/src/types.rs
@@ -83,9 +83,9 @@ impl PyProcessingResult {
         let mut last_end = 0;
 
         for &boundary_offset in &self.boundaries {
-            // boundary_offset points to the sentence-ending punctuation
-            // We want to include it in the sentence
-            let end = (boundary_offset + 1).min(text.len());
+            // boundary_offset points to the position AFTER the sentence-ending punctuation
+            // So we use it directly as the end position
+            let end = boundary_offset.min(text.len());
 
             if end > last_end {
                 if let Some(sentence) = text.get(last_end..end) {

--- a/sakurs-py/tests/test_basic.py
+++ b/sakurs-py/tests/test_basic.py
@@ -84,3 +84,60 @@ def test_sentence_count(text, min_sentences):
 
     sentences = sakurs.split(text)
     assert len(sentences) >= min_sentences
+
+
+def test_japanese_basic():
+    """Test basic Japanese sentence tokenization."""
+    if sakurs is None:
+        pytest.skip("sakurs module not built yet")
+
+    # Test with common Japanese punctuation
+    text = "こんにちは。元気ですか？はい、元気です！"
+    sentences = sakurs.split(text, language="ja")
+
+    assert len(sentences) == 3
+    assert sentences[0] == "こんにちは。"
+    assert sentences[1] == "元気ですか？"
+    assert sentences[2] == "はい、元気です！"
+
+
+def test_japanese_with_brackets():
+    """Test Japanese sentence tokenization with brackets."""
+    if sakurs is None:
+        pytest.skip("sakurs module not built yet")
+
+    # Test with Japanese quotation marks (鉤括弧)
+    text = "彼は「おはよう！」と言った。「本当ですか？」と私は聞きました。"
+    sentences = sakurs.split(text, language="ja")
+    assert len(sentences) == 2
+    assert sentences[0] == "彼は「おはよう！」と言った。"
+    assert sentences[1] == "「本当ですか？」と私は聞きました。"
+
+
+def test_japanese_mixed_punctuation():
+    """Test Japanese with various punctuation marks."""
+    if sakurs is None:
+        pytest.skip("sakurs module not built yet")
+
+    # Test with mixed punctuation including exclamation marks
+    text = "すごい！これは素晴らしいです。「本当に？」と彼女は尋ねた。はい、本当です！"
+    sentences = sakurs.split(text, language="ja")
+    assert len(sentences) == 4
+    assert sentences[0] == "すごい！"
+    assert sentences[1] == "これは素晴らしいです。"
+    assert sentences[2] == "「本当に？」と彼女は尋ねた。"
+    assert sentences[3] == "はい、本当です！"
+
+
+def test_japanese_nested_quotes():
+    """Test Japanese with nested quotation marks."""
+    if sakurs is None:
+        pytest.skip("sakurs module not built yet")
+
+    # Test with nested quotes and various end punctuation
+    text = "田中さんは「彼女が『すごい！』と言った」と話しました。面白いですね？"
+    sentences = sakurs.split(text, language="ja")
+    assert len(sentences) == 2
+    # First sentence contains nested quotes
+    assert "『すごい！』" in sentences[0]
+    assert sentences[1] == "面白いですね？"


### PR DESCRIPTION
## Summary

This PR adds comprehensive tests for Japanese sentence boundary detection in the Python bindings, fixes a critical bug in boundary offset interpretation, and improves the Python development workflow to avoid stale editable install issues.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [ ] 🎨 Code style/formatting (no functional changes)
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [x] 🧪 Test addition or update
- [x] 🔧 Build/CI configuration change

## Related Issues

- Fixes the issue where Japanese language rules were not functioning correctly in Python bindings
- Addresses the development environment issue with stale editable installs from `maturin develop`

## Changes Made

### Core Changes
- Fixed boundary offset interpretation in `src/types.rs` where `boundary_offset + 1` was incorrectly incrementing the offset
- Updated the sentence extraction logic to use the boundary offset directly as the end position

### Testing Changes
- Added 4 comprehensive Japanese test cases to `tests/test_basic.py`:
  - Basic punctuation test (。, ？, ！)
  - Text with Japanese quotation marks (鉤括弧)
  - Mixed punctuation patterns
  - Nested quotation marks
- Added Rust unit tests in `src/lib.rs` to verify Japanese processing at the bindings level

### Documentation Changes
- Updated Ruff configuration in `pyproject.toml` to allow fullwidth punctuation characters in test files
- Added Python bindings development section to `CLAUDE.md` with troubleshooting guide
- Enhanced `sakurs-py/README.md` with detailed development workflow and warnings about editable installs
- Updated Makefile `py-dev` target to use wheel builds instead of `maturin develop`
- Updated CI workflow to use wheel builds for consistent behavior

## How Has This Been Tested?

### Test Environment
- Rust version: 1.81+
- Operating System: macOS Darwin 24.5.0
- Architecture: arm64

### Test Cases
- [x] Unit tests pass (`cargo test`)
- [x] Integration tests pass
- [ ] Benchmarks run successfully (if applicable)
- [x] Manual testing performed

### Performance Impact
No performance impact - this is a bug fix that corrects the interpretation of already-calculated boundary offsets.

## Algorithm/Architecture Impact

- [ ] This change affects the core algorithm
- [ ] This change affects the hexagonal architecture layers
- [ ] This change maintains monoid properties
- [ ] This change preserves parallel processing capabilities

## Checklist

### Code Quality
- [x] I have performed a self-review of my code
- [x] My code follows the project's style guidelines (`cargo fmt`)
- [x] I have resolved all `cargo clippy` warnings
- [ ] I have added rustdoc comments for public APIs
- [x] My code is properly documented with clear variable names and comments for complex logic

### Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added property tests for core algorithm changes (if applicable)
- [ ] I have included benchmarks for performance-critical changes (if applicable)

### Documentation
- [x] I have updated relevant documentation
- [ ] I have updated the CHANGELOG.md (if applicable)
- [x] I have read and understood the [Architecture Documentation](docs/ARCHITECTURE.md)
- [ ] I have considered the impact on the [Delta-Stack Algorithm](docs/DELTA_STACK_ALGORITHM.md)

### Dependencies
- [x] I have not introduced unnecessary dependencies
- [ ] New dependencies are properly justified in the commit message
- [ ] Dependencies are added to the appropriate workspace configuration

## Screenshots/GIFs

N/A

## Additional Context

### Development Environment Issue

During development, I discovered a critical issue with Python development tooling where `maturin develop` creates editable installs that don't update properly when the Rust code is rebuilt. This led to stale `.so` files being used despite rebuilds, causing confusion during debugging.

### Solution Implemented

1. **Makefile Update**: Changed `py-dev` target to build and install wheels instead of using `maturin develop`
2. **Documentation**: Added comprehensive warnings and guidelines in multiple places:
   - `CLAUDE.md`: New Python development section with troubleshooting
   - `sakurs-py/README.md`: Detailed development workflow
   - Makefile output: Helpful hints about using `.venv/bin/python` directly
3. **CI Update**: Aligned CI workflow with the recommended development approach

This ensures future contributors won't encounter the same frustrating issue and will have clear guidance on the correct development workflow.

## Reviewer Notes

1. Please verify that the Japanese tests cover appropriate edge cases for sentence boundary detection
2. The boundary offset fix is minimal but critical - it corrects how we interpret the boundary offsets returned by the core algorithm
3. The development workflow changes are based on actual issues encountered and should significantly improve the developer experience

---

**Note for Reviewers**: Please ensure changes maintain the mathematical properties of the Delta-Stack Monoid algorithm and don't break parallel processing guarantees.