### PR TITLE
feat: externalize sentence starters from hardcoded list to language configuration

### DIFF
--- a/sakurs-cli/src/commands/generate_config.rs
+++ b/sakurs-cli/src/commands/generate_config.rs
@@ -127,6 +127,27 @@ common = ["etc", "vs", "e.g", "i.e"]
 # geographic = ["St", "Ave", "Blvd"]
 # measurement = ["oz", "lb", "kg", "km"]
 # month = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
+
+# Sentence starters configuration
+[sentence_starters]
+# Whether to use case-sensitive matching (default: false)
+case_sensitive = false
+
+# Whether to treat any uppercase word as a sentence starter (default: false)
+# When false, only words in the configured lists are considered sentence starters
+use_uppercase_fallback = false
+
+# Minimum word length to consider (default: 1)
+min_word_length = 1
+
+# Categories of sentence starter words
+# Words must appear with uppercase first letter to be recognized as sentence starters
+pronouns = ["I", "You", "He", "She", "It", "We", "They"]
+articles = ["The", "A", "An"]
+demonstratives = ["This", "That", "These", "Those"]
+conjunctions = ["However", "But", "And", "So", "Therefore"]
+interrogatives = ["What", "When", "Where", "Why", "How", "Who"]
+# Add more categories as needed
 "#,
             self.language_code, self.language_code
         )
@@ -163,6 +184,7 @@ mod tests {
         assert!(template.contains("[metadata]"));
         assert!(template.contains("[terminators]"));
         assert!(template.contains("[abbreviations]"));
+        assert!(template.contains("[sentence_starters]"));
     }
 
     #[test]

--- a/sakurs-cli/src/commands/validate.rs
+++ b/sakurs-cli/src/commands/validate.rs
@@ -76,6 +76,9 @@ pairs = []
 [suppression]
 
 [abbreviations]
+
+[sentence_starters]
+common = ["The", "A"]
 "#;
 
         let mut temp_file = NamedTempFile::new().unwrap();

--- a/sakurs-cli/tests/external_language_config.rs
+++ b/sakurs-cli/tests/external_language_config.rs
@@ -34,6 +34,7 @@ fn test_generate_config_command() {
     assert!(content.contains("[metadata]"));
     assert!(content.contains("[terminators]"));
     assert!(content.contains("[abbreviations]"));
+    assert!(content.contains("[sentence_starters]"));
 }
 
 /// Test validating a valid configuration
@@ -64,6 +65,9 @@ pairs = [
 
 [abbreviations]
 common = ["Mr", "Mrs", "Dr"]
+
+[sentence_starters]
+common = ["The", "A"]
 "#;
 
     fs::write(&config_path, config_content).unwrap();
@@ -104,6 +108,9 @@ pairs = []
 [suppression]
 
 [abbreviations]
+
+[sentence_starters]
+common = ["The"]
 "#;
 
     fs::write(&config_path, config_content).unwrap();
@@ -157,6 +164,9 @@ fast_patterns = [
 [abbreviations]
 titles = ["Dr", "Mr", "Mrs", "Ms"]
 common = ["etc", "vs"]
+
+[sentence_starters]
+common = ["The", "He", "She", "It", "They", "We", "Hello", "How", "I"]
 "#;
 
     fs::write(&config_path, config_content).unwrap();
@@ -205,6 +215,9 @@ pairs = []
 [suppression]
 
 [abbreviations]
+
+[sentence_starters]
+common = ["The"]
 "#;
 
     fs::write(&config_path, config_content).unwrap();
@@ -276,6 +289,9 @@ pairs = []
 [suppression]
 
 [abbreviations]
+
+[sentence_starters]
+common = ["The"]
 "#;
 
     fs::write(&config_path, config_content).unwrap();
@@ -319,6 +335,9 @@ pairs = []
 [suppression]
 
 [abbreviations]
+
+[sentence_starters]
+common = ["The"]
 "#;
 
     fs::write(&config_path, config_content).unwrap();

--- a/sakurs-core/configs/languages/english.toml
+++ b/sakurs-core/configs/languages/english.toml
@@ -109,3 +109,57 @@ month = [
 military = [
     "Gen", "Col", "Maj", "Capt", "Lt", "Sgt", "Cpl", "Pvt", "Adm"
 ]
+
+[sentence_starters]
+case_sensitive = false
+use_uppercase_fallback = false  # Only listed words are sentence starters
+min_word_length = 1
+
+# Personal pronouns
+pronouns = [
+    "I", "You", "He", "She", "It", "We", "They"
+]
+
+# Demonstrative pronouns
+demonstratives = [
+    "This", "That", "These", "Those"
+]
+
+# Articles and determiners
+articles = [
+    "The", "A", "An"
+]
+
+# Location adverbs
+location_adverbs = [
+    "There", "Here"
+]
+
+# Time adverbs
+time_adverbs = [
+    "Now", "Then"
+]
+
+# Conjunctions and transitions
+conjunctions = [
+    "However", "But", "And", "So", "Therefore", "Moreover", "Furthermore",
+    "Meanwhile", "Finally", "Also", "Additionally", "Nevertheless", "Nonetheless",
+    "Consequently", "Hence", "Thus"
+]
+
+# Question words
+interrogatives = [
+    "What", "When", "Where", "Why", "How", "Who", "Which", "Whose", "Whom"
+]
+
+# Common sentence starters that are often found after abbreviations
+common_starters = [
+    "Yes", "No", "Well", "Oh", "Ah", "Indeed", "Perhaps", "Maybe", 
+    "Unfortunately", "Fortunately", "Surprisingly", "Interestingly",
+    "Recently", "Currently", "Previously", "Generally", "Specifically",
+    "Usually", "Often", "Sometimes", "Rarely", "Never", "Always",
+    "Today", "Yesterday", "Tomorrow", "Later", "Earlier",
+    "First", "Second", "Third", "Next", "Last", "Finally",
+    "For", "Since", "Because", "Although", "While", "If", "Unless",
+    "After", "Before", "During", "Throughout", "Despite", "Without"
+]

--- a/sakurs-core/configs/languages/japanese.toml
+++ b/sakurs-core/configs/languages/japanese.toml
@@ -49,3 +49,48 @@ fast_patterns = [
 common = [
     "Mr", "Dr", "Inc", "Ltd", "etc", "vs", "No"
 ]
+
+[sentence_starters]
+case_sensitive = true  # Japanese doesn't have case distinction
+use_uppercase_fallback = false  # Not applicable to Japanese
+min_word_length = 1
+
+# Sequential conjunctions
+sequential = [
+    "そして", "それから", "次に", "その後", "続いて"
+]
+
+# Adversative conjunctions
+adversative = [
+    "しかし", "だが", "けれども", "でも", "ところが", "しかしながら"
+]
+
+# Causal conjunctions
+causal = [
+    "だから", "そのため", "したがって", "ゆえに", "それで"
+]
+
+# Additional conjunctions
+additional = [
+    "また", "さらに", "そのうえ", "しかも", "加えて"
+]
+
+# Explanatory transitions
+explanatory = [
+    "つまり", "すなわち", "要するに", "言い換えると", "具体的には"
+]
+
+# Conditional transitions
+conditional = [
+    "もし", "仮に", "万が一", "たとえ"
+]
+
+# Conclusive transitions
+conclusive = [
+    "結局", "最終的に", "結論として", "まとめると"
+]
+
+# Other formal transitions
+formal = [
+    "なお", "ただし", "ちなみに", "ところで", "一方"
+]

--- a/sakurs-core/src/application/parser/mod.rs
+++ b/sakurs-core/src/application/parser/mod.rs
@@ -435,7 +435,8 @@ mod parser_tests {
             .map(|b| b.local_offset)
             .collect();
 
-        // Should not create boundaries after some abbreviations
+        // With use_uppercase_fallback=false, "Smith" is NOT a sentence starter
+        // So NO boundary should be created after "Dr."
         assert!(!boundary_positions.contains(&3)); // After "Dr." (followed by "Smith", not a sentence starter)
         assert!(!boundary_positions.contains(&95)); // After "$2.5" decimal
 

--- a/sakurs-core/src/domain/cross_chunk.rs
+++ b/sakurs-core/src/domain/cross_chunk.rs
@@ -14,10 +14,11 @@ use crate::domain::{
 use std::collections::HashMap;
 
 /// Simple function to check if a word is commonly a sentence starter
-/// This is a temporary implementation to replace the deleted EnglishSentenceStarterRule
+/// This is a simplified version used specifically for cross-chunk validation.
+/// The main implementation with configurable language-specific rules is in ConfigurableLanguageRules.
 fn is_sentence_starter(word: &str) -> bool {
-    // Common sentence starters that are typically capitalized
-    // This is a simplified version - in practice, this would be more sophisticated
+    // For cross-chunk validation, we use a simple heuristic:
+    // A word is considered a sentence starter if it begins with uppercase and has length > 1
     let first_char = word.chars().next().unwrap_or(' ');
     first_char.is_uppercase() && word.len() > 1
 }

--- a/sakurs-core/src/domain/language/mod.rs
+++ b/sakurs-core/src/domain/language/mod.rs
@@ -337,7 +337,8 @@ mod tests {
                 .to_string(),
         };
 
-        // Should not detect boundary after "Dr."
+        // "Dr." followed by "Smith" - "Smith" starts with uppercase but is not in
+        // the sentence starter list, and use_uppercase_fallback=false, so no boundary
         assert_eq!(
             rules.detect_sentence_boundary(&context),
             BoundaryDecision::NotBoundary

--- a/sakurs-core/tests/apostrophe_handling_tests.rs
+++ b/sakurs-core/tests/apostrophe_handling_tests.rs
@@ -215,6 +215,7 @@ fn test_multi_period_abbreviations() {
         ("I work at the U.N. headquarters.", vec![32]),
         ("She has a Ph.D. in physics.", vec![27]),
         ("The E.U. is a union.", vec![20]),
+        // "today" is lowercase, not a sentence starter
         ("He lives in Washington D.C. today.", vec![34]),
         // Multiple abbreviations
         ("Dr. Smith has a Ph.D. from M.I.T. in Cambridge.", vec![47]),

--- a/sakurs-core/tests/configurable_language_tests.rs
+++ b/sakurs-core/tests/configurable_language_tests.rs
@@ -23,7 +23,7 @@ fn test_english_abbreviations() {
     let text = "Dr. Smith works at Apple Inc. and lives on Main St. in the city.";
     let result = processor.process(Input::from_text(text)).unwrap();
 
-    // Should recognize abbreviations and not split
+    // "and" is lowercase, not a sentence starter (even though "And" is in the list)
     assert_eq!(result.boundaries.len(), 1);
     assert_eq!(result.boundaries[0].offset, 64); // Only after the final period
 }


### PR DESCRIPTION
## Summary

This PR externalizes the hardcoded English-specific sentence starter words from `ConfigurableLanguageRules` into a flexible, language-configurable system. This enables better multilingual support and improves sentence boundary detection accuracy after abbreviations.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting (no functional changes)
- [x] ♻️ Refactoring (no functional changes)
- [x] ⚡ Performance improvement
- [ ] 🧪 Test addition or update
- [ ] 🔧 Build/CI configuration change

## Related Issues

N/A - Pre-v0.1.0 improvement to remove language-specific hardcoding

## Changes Made

### Core Changes
- Removed 44 hardcoded English sentence starter words from `ConfigurableLanguageRules`
- Added new `SentenceStarterConfig` type to support language-specific configurations
- Refactored sentence starter detection to use O(1) HashSet lookups instead of O(n) array search
- Implemented correct logic: words must be in the configured list AND start with uppercase to be considered sentence starters

### Testing Changes
- Updated all test configurations to include the required `[sentence_starters]` section
- Fixed test expectations to match the new behavior where proper nouns like "Smith" are not automatically treated as sentence starters

### Documentation Changes
- Updated `ADDING_LANGUAGES.md` with detailed documentation about sentence starter configuration
- Added comprehensive inline documentation for the new configuration type
- Updated configuration templates in CLI commands

## How Has This Been Tested?

### Test Environment
- Rust version: 1.81+
- Operating System: macOS
- Architecture: ARM64

### Test Cases
- [x] Unit tests pass (`cargo test`)
- [x] Integration tests pass
- [x] Benchmarks run successfully (if applicable)
- [x] Manual testing performed

### Performance Impact
The change improves performance by switching from O(n) linear array search to O(1) HashSet lookups for sentence starter detection.

## Algorithm/Architecture Impact

- [ ] This change affects the core algorithm
- [x] This change affects the hexagonal architecture layers
- [ ] This change maintains monoid properties
- [ ] This change preserves parallel processing capabilities

## Checklist

### Code Quality
- [x] I have performed a self-review of my code
- [x] My code follows the project's style guidelines (`cargo fmt`)
- [x] I have resolved all `cargo clippy` warnings
- [x] I have added rustdoc comments for public APIs
- [x] My code is properly documented with clear variable names and comments for complex logic

### Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added property tests for core algorithm changes (if applicable)
- [ ] I have included benchmarks for performance-critical changes (if applicable)

### Documentation
- [x] I have updated relevant documentation
- [ ] I have updated the CHANGELOG.md (if applicable)
- [x] I have read and understood the [Architecture Documentation](docs/ARCHITECTURE.md)
- [ ] I have considered the impact on the [Delta-Stack Algorithm](docs/DELTA_STACK_ALGORITHM.md)

### Dependencies
- [x] I have not introduced unnecessary dependencies
- [x] New dependencies are properly justified in the commit message
- [x] Dependencies are added to the appropriate workspace configuration

## Screenshots/GIFs

N/A

## Additional Context

This is a breaking change that requires all language configuration files to include a `[sentence_starters]` section. Since we're pre-v0.1.0, this is the ideal time to make such architectural improvements.

### Migration Guide

All language configuration files must now include:

```toml
[sentence_starters]
case_sensitive = false
use_uppercase_fallback = false
min_word_length = 1

# Categories of sentence starter words
pronouns = ["I", "You", "He", "She"]
articles = ["The", "A", "An"]
# ... more categories
```

## Reviewer Notes

Please pay special attention to:
1. The logic in `is_sentence_starter()` that requires both uppercase first letter AND presence in the configured list
2. The migration of all test configurations to include the new section
3. The performance improvement from array to HashSet

---

**Note for Reviewers**: Please ensure changes maintain the mathematical properties of the Delta-Stack Monoid algorithm and don't break parallel processing guarantees.