### PR TITLE
fix: update release workflow to support workspace version management

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,26 +46,24 @@ jobs:
       
       - name: Verify Cargo.toml versions match tag
         run: |
-          # Check sakurs-core version
-          CORE_VERSION=$(grep -E '^version = ' sakurs-core/Cargo.toml | head -1 | cut -d'"' -f2)
-          if [[ "$CORE_VERSION" != "${{ steps.version.outputs.version }}" ]]; then
-            echo "Error: sakurs-core version ($CORE_VERSION) doesn't match tag (${{ steps.version.outputs.version }})"
+          # Get workspace version
+          WORKSPACE_VERSION=$(grep -E '^version = ' Cargo.toml | head -1 | cut -d'"' -f2)
+          
+          # Check workspace version matches tag
+          if [[ "$WORKSPACE_VERSION" != "${{ steps.version.outputs.version }}" ]]; then
+            echo "Error: Workspace version ($WORKSPACE_VERSION) doesn't match tag (${{ steps.version.outputs.version }})"
             exit 1
           fi
           
-          # Check sakurs-cli version
-          CLI_VERSION=$(grep -E '^version = ' sakurs-cli/Cargo.toml | head -1 | cut -d'"' -f2)
-          if [[ "$CLI_VERSION" != "${{ steps.version.outputs.version }}" ]]; then
-            echo "Error: sakurs-cli version ($CLI_VERSION) doesn't match tag (${{ steps.version.outputs.version }})"
-            exit 1
-          fi
+          # Verify all crates use workspace version
+          for crate in sakurs-core sakurs-cli sakurs-py; do
+            if ! grep -q "^version\.workspace = true" "$crate/Cargo.toml"; then
+              echo "Error: $crate doesn't use workspace version"
+              exit 1
+            fi
+          done
           
-          # Check sakurs-py version
-          PY_VERSION=$(grep -E '^version = ' sakurs-py/Cargo.toml | head -1 | cut -d'"' -f2)
-          if [[ "$PY_VERSION" != "${{ steps.version.outputs.version }}" ]]; then
-            echo "Error: sakurs-py version ($PY_VERSION) doesn't match tag (${{ steps.version.outputs.version }})"
-            exit 1
-          fi
+          echo "✓ All versions correctly set to $WORKSPACE_VERSION"
     
     outputs:
       version: ${{ steps.version.outputs.version }}


### PR DESCRIPTION
## Summary

This PR fixes the release workflow that was failing due to incorrect version extraction. The workflow was looking for `version = "X.X.X"` format in individual crate Cargo.toml files, but our crates use workspace-level version management with `version.workspace = true`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting (no functional changes)
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test addition or update
- [x] 🔧 Build/CI configuration change

## Related Issues

Fixes the release workflow failure that occurred after pushing v0.1.0 tag.

## Changes Made

### Core Changes
- Updated version extraction logic to read from workspace root Cargo.toml instead of individual crate files
- Added validation to ensure all crates use `version.workspace = true`

### Testing Changes
- N/A

### Documentation Changes
- N/A

## How Has This Been Tested?

### Test Environment
- Rust version: 1.81
- Operating System: macOS
- Architecture: arm64

### Test Cases
- [x] Unit tests pass (`cargo test`)
- [ ] Integration tests pass
- [ ] Benchmarks run successfully (if applicable)
- [x] Manual testing performed

Tested locally by simulating the version extraction logic:
```bash
# Workspace version extraction
grep -E '^version = ' Cargo.toml | head -1 | cut -d'"' -f2
# Output: 0.1.0

# Crate verification
grep -q "^version\.workspace = true" sakurs-core/Cargo.toml && echo "✓ Uses workspace version"
# Output: ✓ Uses workspace version
```

### Performance Impact
N/A - This is a CI/CD configuration change only.

## Algorithm/Architecture Impact

- [ ] This change affects the core algorithm
- [ ] This change affects the hexagonal architecture layers
- [ ] This change maintains monoid properties
- [ ] This change preserves parallel processing capabilities

## Checklist

### Code Quality
- [x] I have performed a self-review of my code
- [x] My code follows the project's style guidelines (`cargo fmt`)
- [x] I have resolved all `cargo clippy` warnings
- [ ] I have added rustdoc comments for public APIs
- [x] My code is properly documented with clear variable names and comments for complex logic

### Testing
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added property tests for core algorithm changes (if applicable)
- [ ] I have included benchmarks for performance-critical changes (if applicable)

### Documentation
- [ ] I have updated relevant documentation
- [ ] I have updated the CHANGELOG.md (if applicable)
- [ ] I have read and understood the [Architecture Documentation](docs/ARCHITECTURE.md)
- [ ] I have considered the impact on the [Delta-Stack Algorithm](docs/DELTA_STACK_ALGORITHM.md)

### Dependencies
- [x] I have not introduced unnecessary dependencies
- [ ] New dependencies are properly justified in the commit message
- [ ] Dependencies are added to the appropriate workspace configuration

## Screenshots/GIFs

N/A

## Additional Context

The release workflow failed with error:
```
sakurs-core version () doesn't match tag (0.1.0)
```

This was because the workflow expected `version = "0.1.0"` format in individual Cargo.toml files, but our project uses Cargo workspace version management where each crate has `version.workspace = true` and the actual version is defined in the root Cargo.toml.

## Reviewer Notes

This fix ensures the workflow correctly extracts the version from the workspace root and validates that all crates are properly configured to use the workspace version.