### PR TITLE
fix: prevent artifact name collision in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,7 +218,7 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-${{ matrix.platform.target }}
+          name: wheels-${{ runner.os }}-${{ matrix.platform.target }}
           path: sakurs-py/dist
 
   # Upload all wheels to PyPI


### PR DESCRIPTION
## Summary

This PR fixes the artifact name collision issue in the release workflow that caused the PyPI upload to fail during the v0.1.0 release.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting (no functional changes)
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test addition or update
- [x] 🔧 Build/CI configuration change

## Related Issues

Fixes the artifact name collision that occurred during v0.1.0 release, preventing macOS x86_64 wheel upload.

## Changes Made

### Core Changes
- Modified artifact naming in release workflow to include OS name using `${{ runner.os }}`
- Changed from `wheels-${{ matrix.platform.target }}` to `wheels-${{ runner.os }}-${{ matrix.platform.target }}`

### Testing Changes
- N/A

### Documentation Changes
- N/A

## How Has This Been Tested?

### Test Environment
- Rust version: 1.81
- Operating System: macOS
- Architecture: arm64

### Test Cases
- [x] Unit tests pass (`cargo test`)
- [ ] Integration tests pass
- [ ] Benchmarks run successfully (if applicable)
- [x] Manual testing performed

### Performance Impact
N/A - This is a CI/CD configuration change only.

## Algorithm/Architecture Impact

- [ ] This change affects the core algorithm
- [ ] This change affects the hexagonal architecture layers
- [ ] This change maintains monoid properties
- [ ] This change preserves parallel processing capabilities

## Checklist

### Code Quality
- [x] I have performed a self-review of my code
- [x] My code follows the project's style guidelines (`cargo fmt`)
- [x] I have resolved all `cargo clippy` warnings
- [ ] I have added rustdoc comments for public APIs
- [x] My code is properly documented with clear variable names and comments for complex logic

### Testing
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added property tests for core algorithm changes (if applicable)
- [ ] I have included benchmarks for performance-critical changes (if applicable)

### Documentation
- [ ] I have updated relevant documentation
- [ ] I have updated the CHANGELOG.md (if applicable)
- [ ] I have read and understood the [Architecture Documentation](docs/ARCHITECTURE.md)
- [ ] I have considered the impact on the [Delta-Stack Algorithm](docs/DELTA_STACK_ALGORITHM.md)

### Dependencies
- [x] I have not introduced unnecessary dependencies
- [ ] New dependencies are properly justified in the commit message
- [ ] Dependencies are added to the appropriate workspace configuration

## Screenshots/GIFs

N/A

## Additional Context

The issue occurred because both Linux x86_64 and macOS x86_64 builds were using the same artifact name `wheels-x86_64`. This caused the macOS build to fail when uploading its artifact, as an artifact with that name already existed from the Linux build.

The new naming scheme will produce:
- `wheels-Linux-x86_64` for Linux builds
- `wheels-macOS-x86_64` for macOS Intel builds
- `wheels-macOS-aarch64` for macOS ARM builds
- `wheels-Windows-x64` for Windows builds

## Reviewer Notes

This is a minimal fix that resolves the immediate issue. The download pattern `wheels-*` remains unchanged and will correctly match all the new artifact names.